### PR TITLE
Base JSON:API support for landing pages

### DIFF
--- a/drupal/composer.patches.json
+++ b/drupal/composer.patches.json
@@ -1,6 +1,10 @@
 
 {
   "patches": {
+    "drupal/core": {
+      "https://www.drupal.org/node/2942975": "https://www.drupal.org/files/issues/2020-07-07/2942975-116.patch",
+      "https://www.drupal.org/node/3066751": "https://www.drupal.org/files/issues/2020-06-12/3066751-42.patch"
+    },
     "drupal/media_entity_facebook": {
       "https://www.drupal.org/node/3120085": "https://www.drupal.org/files/issues/2020-03-31/3120085-media-library-add-5.patch"
     },

--- a/drupal/config/dev/core.extension.yml
+++ b/drupal/config/dev/core.extension.yml
@@ -29,11 +29,13 @@ module:
   image: 0
   image_style_quality: 0
   inline_form_errors: 0
+  jsonapi: 0
   layout_builder: 0
   layout_builder_browser: 0
   layout_builder_iframe_modal: 0
   layout_discovery: 0
   link: 0
+  manati_landing_pages: 0
   media: 0
   media_entity_facebook: 0
   media_entity_instagram: 0

--- a/drupal/config/sync/core.entity_form_display.node.landing_page.default.yml
+++ b/drupal/config/sync/core.entity_form_display.node.landing_page.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.landing_page.field_blocks
     - field.field.node.landing_page.layout_builder__layout
     - node.type.landing_page
   module:
@@ -20,6 +21,16 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_blocks:
+    weight: 121
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
   path:
     type: path
     weight: 30

--- a/drupal/config/sync/core.entity_view_display.node.landing_page.default.yml
+++ b/drupal/config/sync/core.entity_view_display.node.landing_page.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.landing_page.field_blocks
     - field.field.node.landing_page.layout_builder__layout
     - node.type.landing_page
   module:
@@ -19,7 +20,7 @@ third_party_settings:
         layout_settings:
           label: ''
         components:
-          7e52566e-f849-433c-8313-471f4ffb278a:
+          -
             uuid: 7e52566e-f849-433c-8313-471f4ffb278a
             region: content
             configuration:
@@ -29,6 +30,22 @@ third_party_settings:
               id: 'extra_field_block:node:landing_page:links'
             additional: {  }
             weight: 0
+          -
+            uuid: 04406c5e-d5ef-4f88-9182-fc5954980b94
+            region: content
+            configuration:
+              label_display: '0'
+              context_mapping:
+                entity: layout_builder.entity
+              id: 'field_block:node:landing_page:field_blocks'
+              formatter:
+                label: above
+                settings:
+                  link: true
+                third_party_settings: {  }
+                type: entity_reference_label
+            additional: {  }
+            weight: 1
         third_party_settings: {  }
 _core:
   default_config_hash: NTd35l9r7eW0NhNAkIB142lLKF0auqs52cBkndzqNQU
@@ -37,6 +54,14 @@ targetEntityType: node
 bundle: landing_page
 mode: default
 content:
+  field_blocks:
+    weight: 101
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
   links:
     weight: 100
     settings: {  }

--- a/drupal/config/sync/core.entity_view_display.node.landing_page.full.yml
+++ b/drupal/config/sync/core.entity_view_display.node.landing_page.full.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.full
+    - field.field.node.landing_page.field_blocks
     - field.field.node.landing_page.layout_builder__layout
     - node.type.landing_page
   module:
@@ -20,7 +21,7 @@ third_party_settings:
         layout_settings:
           label: ''
         components:
-          c58c6920-5873-4384-a9d7-d27d611dee01:
+          -
             uuid: c58c6920-5873-4384-a9d7-d27d611dee01
             region: content
             configuration:
@@ -44,4 +45,5 @@ content:
     third_party_settings: {  }
     region: content
 hidden:
+  field_blocks: true
   layout_builder__layout: true

--- a/drupal/config/sync/core.entity_view_display.node.landing_page.teaser.yml
+++ b/drupal/config/sync/core.entity_view_display.node.landing_page.teaser.yml
@@ -4,6 +4,7 @@ status: false
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
+    - field.field.node.landing_page.field_blocks
     - field.field.node.landing_page.layout_builder__layout
     - node.type.landing_page
   module:
@@ -21,4 +22,5 @@ content:
     third_party_settings: {  }
     region: content
 hidden:
+  field_blocks: true
   layout_builder__layout: true

--- a/drupal/config/sync/core.extension.yml
+++ b/drupal/config/sync/core.extension.yml
@@ -28,11 +28,13 @@ module:
   image: 0
   image_style_quality: 0
   inline_form_errors: 0
+  jsonapi: 0
   layout_builder: 0
   layout_builder_browser: 0
   layout_builder_iframe_modal: 0
   layout_discovery: 0
   link: 0
+  manati_landing_pages: 0
   media: 0
   media_entity_facebook: 0
   media_entity_instagram: 0

--- a/drupal/config/sync/field.field.node.landing_page.field_blocks.yml
+++ b/drupal/config/sync/field.field.node.landing_page.field_blocks.yml
@@ -1,0 +1,25 @@
+uuid: 2879768e-969f-4ed4-b050-d3762c5e6760
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_blocks
+    - node.type.landing_page
+id: node.landing_page.field_blocks
+field_name: field_blocks
+entity_type: node
+bundle: landing_page
+label: Blocks
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: views
+  handler_settings:
+    view:
+      view_name: non_reusable_blocks
+      display_name: entity_reference_1
+      arguments: {  }
+field_type: entity_reference

--- a/drupal/config/sync/field.storage.node.field_blocks.yml
+++ b/drupal/config/sync/field.storage.node.field_blocks.yml
@@ -1,0 +1,20 @@
+uuid: e8bdc9cc-4690-42c1-bd20-924ab5961141
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - node
+id: node.field_blocks
+field_name: field_blocks
+entity_type: node
+type: entity_reference
+settings:
+  target_type: block_content
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/drupal/config/sync/jsonapi.settings.yml
+++ b/drupal/config/sync/jsonapi.settings.yml
@@ -1,0 +1,4 @@
+langcode: en
+read_only: true
+_core:
+  default_config_hash: p_qzzTwtOMiIPE7CyG0wD6M-UCpBp6Y5E4LhNCnCRpY

--- a/drupal/config/sync/views.view.non_reusable_blocks.yml
+++ b/drupal/config/sync/views.view.non_reusable_blocks.yml
@@ -1,0 +1,178 @@
+uuid: 62318178-35b2-4559-ab41-226533154a53
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+id: non_reusable_blocks
+label: 'Non-reusable blocks'
+module: views
+description: ''
+tag: ''
+base_table: block_content_field_data
+base_field: id
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: none
+        options: {  }
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: mini
+        options:
+          items_per_page: 10
+          offset: 0
+          id: 0
+          total_pages: null
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          tags:
+            previous: ‹‹
+            next: ››
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: fields
+        options:
+          inline: {  }
+          separator: ''
+          hide_empty: false
+          default_field_elements: true
+      fields:
+        info:
+          table: block_content_field_data
+          field: info
+          id: info
+          entity_type: null
+          entity_field: info
+          plugin_id: field
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      filters: {  }
+      sorts: {  }
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+      tags: {  }
+  entity_reference_1:
+    display_plugin: entity_reference
+    id: entity_reference_1
+    display_title: 'Entity Reference'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      pager:
+        type: none
+        options:
+          offset: 0
+      style:
+        type: entity_reference
+        options:
+          search_fields:
+            info: info
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+      tags: {  }

--- a/drupal/modules/custom/manati_landing_pages/manati_landing_pages.info.yml
+++ b/drupal/modules/custom/manati_landing_pages/manati_landing_pages.info.yml
@@ -1,0 +1,6 @@
+name: 'Manati Landing pages'
+type: module
+core_version_requirement: ^8.8 || ^9
+dependencies:
+  - drupal:node
+  - drupal:layout_builder

--- a/drupal/modules/custom/manati_landing_pages/manati_landing_pages.module
+++ b/drupal/modules/custom/manati_landing_pages/manati_landing_pages.module
@@ -21,12 +21,12 @@ function manati_landing_pages_node_update(EntityInterface $node) {
     $block_ids = [];
     foreach($node->layout_builder__layout->getSections() as $section) {
       foreach($section->getComponents() as $component) {
+        $block = \Drupal::entityTypeManager()->getStorage('block_content')->loadRevision($component->get('configuration')['block_revision_id']);
         array_push($block_ids, [
-          'target_id' => $component->get('configuration')['block_revision_id'],
+          'target_id' => $block->id(),
         ]);
       }
     }
-    dump($block_ids);
     $node->field_blocks = $block_ids;
     drupal_register_shutdown_function('_manati_landing_pages_post_update', $node);
   }

--- a/drupal/modules/custom/manati_landing_pages/manati_landing_pages.module
+++ b/drupal/modules/custom/manati_landing_pages/manati_landing_pages.module
@@ -1,0 +1,39 @@
+<?php
+
+use Drupal\Core\Entity\EntityInterface;
+
+/**
+ * Implements hook_form_alter().
+ */
+function manati_landing_pages_form_alter(&$form, &$form_state, $form_id) {
+  $forms = ['node_landing_page_form', 'node_landing_page_edit_form'];
+  if (in_array($form_id, $forms)) {
+    // Hide field_blocks field.
+    $form['field_blocks']['#access'] = FALSE;
+  }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_insert().
+ */
+function manati_landing_pages_node_update(EntityInterface $node) {
+  if ($node->bundle() === 'landing_page') {
+    $block_ids = [];
+    foreach($node->layout_builder__layout->getSections() as $section) {
+      foreach($section->getComponents() as $component) {
+        array_push($block_ids, [
+          'target_id' => $component->get('configuration')['block_revision_id'],
+        ]);
+      }
+    }
+    dump($block_ids);
+    $node->field_blocks = $block_ids;
+    drupal_register_shutdown_function('_manati_landing_pages_post_update', $node);
+  }
+}
+
+function _manati_landing_pages_post_update($node) {
+  if ($node) {
+      $node->save();
+  }
+}


### PR DESCRIPTION
- Apply drupal core patches
- Add `field_blocks` to landing pages to manage inline block relationship
- Add `manati_landing_pages` module
- Enable jsonapi module